### PR TITLE
docs: expand README with setup and GitHub Pages deployment info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,68 @@
-# ExtractPDF4J Site (GitHub Pages ready)
+# ExtractPDF4J Web Site
 
-- Vite `base: './'`
-- Outputs to `/docs`
-- Includes `.nojekyll` in build (copied from `public/`)
+A minimal React front-end for the ExtractPDF4J project built with [Vite](https://vitejs.dev/) and [Tailwind CSS](https://tailwindcss.com/). The project is configured to build directly to a `docs/` folder so it can be served via GitHub Pages.
 
-## Run
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 18 or later (includes `npm`)
+
+## Getting Started
+
+Clone the repository and install dependencies:
+
+```bash
 npm install
+```
+
+### Development Server
+
+Run a hot-reloading development server:
+
+```bash
 npm run dev
+```
 
-## Build
-npm run build   # -> ./docs
+The app will be available at <http://localhost:5173/>.
 
-## Publish on GitHub Pages
-- Push to repo
-- Settings → Pages → Source: **main** / **/docs**
-- Done
+### Production Build
+
+Create an optimized build in the `docs/` directory:
+
+```bash
+npm run build
+```
+
+You can preview the built site locally with:
+
+```bash
+npm run preview
+```
+
+### Deploying to GitHub Pages
+
+1. Run `npm run build` to generate the `docs/` folder.
+2. Commit the build output if you want it served from GitHub Pages.
+3. Push to `main` and enable **Settings → Pages → Source: `main` / `/docs`**.
+4. After Pages is enabled, the site will be available at `https://extractpdf4j.github.io/ExtractPDF4J-WebReact/` (replace `extractpdf4j` with your GitHub username or organization).
+
+## Project Structure
+
+```
+├── public/              # Static assets copied as-is
+├── src/                 # React components and styles
+├── index.html           # Entry HTML template
+├── tailwind.config.js   # Tailwind configuration
+└── vite.config.js       # Vite configuration (base set to './')
+```
+
+## Contributing
+
+1. Fork the repository and create your branch: `git checkout -b feature/your-feature`.
+2. Install dependencies and start the dev server with `npm run dev`.
+3. Run `npm run build` before submitting to ensure the project builds.
+4. Commit your changes and open a pull request.
+
+## License
+
+This project is licensed under the [Apache 2.0 License](LICENSE).
+


### PR DESCRIPTION
## Summary
- document prerequisites, development and build commands
- add project structure and contribution guidelines
- explain GitHub Pages deployment and link to live site

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6cfd8ee60832990174029959591d2